### PR TITLE
Support url kwarg

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,11 @@ Configuration Related
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Added ``url`` keyword to
+  :meth:`vetoes.service.HTTPServiceMixin.call_http_service`
+
 `0.1.1`_ (06-Jan-2017)
 ----------------------
 - Replaced readthedocs with pythonhosted.org.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,8 @@ Configuration Related
 Release History
 ===============
 
-`Next Release`_
----------------
+`0.2.0`_ (10-Jan-2017)
+----------------------
 - Added ``url`` keyword to
   :meth:`vetoes.service.HTTPServiceMixin.call_http_service`
 
@@ -31,6 +31,7 @@ Release History
   :class:`vetoes.config.FeatureFlagMixin`, and
   :class:`vetoes.config.TimeoutConfigurationMixin`
 
-.. _Next Release: https://github.aweber.io/edeliv/vetoes/compare/0.1.1...HEAD
+.. _Next Release: https://github.aweber.io/edeliv/vetoes/compare/0.2.0...HEAD
+.. _0.2.0: https://github.aweber.io/edeliv/vetoes/compare/0.1.1...0.2.0
 .. _0.1.1: https://github.aweber.io/edeliv/vetoes/compare/0.1.0...0.1.1
 .. _0.1.0: https://github.aweber.io/edeliv/vetoes/compare/0.0.0...0.1.0

--- a/tests/service_mixin_tests.py
+++ b/tests/service_mixin_tests.py
@@ -147,3 +147,14 @@ class HTTPServiceMixinTests(testing.AsyncTestCase):
             self.consumer.get_service_url('fetch-stats'),
             method='GET', raise_error=False)
         self.assertIs(response, self.http_response)
+
+    @testing.gen_test
+    def test_that_url_kwarg_skips_service_lookup(self):
+        response = yield self.consumer.call_http_service(
+            'frobinicate', 'GET', url='https://google.com')
+
+        self.http.fetch.assert_called_once_with(
+            'https://google.com', method='GET', raise_error=False)
+        self.assertIs(response, self.http_response)
+        self.sentry_client.tags_context.assert_called_once_with(
+            {'service_invoked': 'frobinicate'})

--- a/vetoes/__init__.py
+++ b/vetoes/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 1)
+version_info = (0, 2, 0)
 version = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
This makes it possible to pass a URL into `call_http_service` instead of having it build the URL from the service lookup.