### PR TITLE
Make timeouts & HTTP service mixins work together.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,8 @@ Release History
 `Next Release`_
 ---------------
 - Updated to work against rejected 3.17
+- Change :meth:`vetoes.service.HTTPServiceMixin.call_http_service` so that
+  it honors timeouts set by :class:`vetoes.config.TimeoutConfigurationMixin`.
 
 `0.2.0`_ (10-Jan-2017)
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,8 @@ Configuration Related
 Release History
 ===============
 
-`Next Release`_
----------------
+`0.3.0`_ (04-Apr-2017)
+----------------------
 - Updated to work against rejected 3.17
 - Change :meth:`vetoes.service.HTTPServiceMixin.call_http_service` so that
   it honors timeouts set by :class:`vetoes.config.TimeoutConfigurationMixin`.
@@ -37,7 +37,8 @@ Release History
   :class:`vetoes.config.FeatureFlagMixin`, and
   :class:`vetoes.config.TimeoutConfigurationMixin`
 
-.. _Next Release: https://github.aweber.io/edeliv/vetoes/compare/0.2.0...HEAD
+.. _Next Release: https://github.aweber.io/edeliv/vetoes/compare/0.3.0...HEAD
+.. _0.3.0: https://github.aweber.io/edeliv/vetoes/compare/0.2.0...0.3.0
 .. _0.2.0: https://github.aweber.io/edeliv/vetoes/compare/0.1.1...0.2.0
 .. _0.1.1: https://github.aweber.io/edeliv/vetoes/compare/0.1.0...0.1.1
 .. _0.1.0: https://github.aweber.io/edeliv/vetoes/compare/0.0.0...0.1.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,4 @@
 coverage
 mock
 nose
-rejected>=3.17,<3.18
+rejected>=3.18,<3.19

--- a/vetoes/__init__.py
+++ b/vetoes/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 2, 0)
+version_info = (0, 3, 0)
 version = '.'.join(str(v) for v in version_info)

--- a/vetoes/service.py
+++ b/vetoes/service.py
@@ -3,7 +3,7 @@ import select
 import socket
 
 from rejected import consumer
-from tornado import gen, httpclient, httputil, ioloop
+from tornado import gen, httpclient, httputil
 
 
 class HTTPServiceMixin(consumer.Consumer):

--- a/vetoes/service.py
+++ b/vetoes/service.py
@@ -145,6 +145,10 @@ class HTTPServiceMixin(consumer.Consumer):
             url = self.get_service_url(
                 service, *path, query_args=kwargs.pop('query_args', None))
 
+        if 'request_timeout' not in kwargs and hasattr(self, 'get_timeout'):
+            kwargs['request_timeout'] = self.get_timeout(
+                function, self.get_timeout(service))
+
         self.set_sentry_context('service_invoked', service)
 
         self.logger.debug('sending %s request to %s', method, url)


### PR DESCRIPTION
Oh... and make things backwards compatible with rejected 3.12 at runtime while we're at it.